### PR TITLE
Disable libva support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+vlc (3.0.17.4-5deepin) unstable; urgency=medium
+
+  * debian/rules:
+    - Disable libva support
+      Deepin currently doesn't have ffmpeg 5.0.
+
+ -- Tianyu Chen <chentianyu1@uniontech.com>  Fri, 17 Mar 2023 16:19:37 +0800
+
 vlc (3.0.17.4-5) unstable; urgency=medium
 
   * debian/rules:

--- a/debian/rules
+++ b/debian/rules
@@ -150,8 +150,6 @@ confflags += \
 	--disable-wasapi \
 	$(NULL)
 
-removeplugins += libva
-
 # Linux specific flags
 ifeq ($(DEB_HOST_ARCH_OS),linux)
 # V4L2 is disabled on kFreeBSD due to a build failure.


### PR DESCRIPTION
Deepin currently doesn't have ffmpeg 5.0.